### PR TITLE
changing upload to type of base 64 string

### DIFF
--- a/src/main/java/com/app/eece4792mealmaster/controllers/StockController.java
+++ b/src/main/java/com/app/eece4792mealmaster/controllers/StockController.java
@@ -14,6 +14,9 @@ import com.app.eece4792mealmaster.services.StockService;
 import com.app.eece4792mealmaster.utils.ApiResponse;
 
 import java.util.HashSet;
+import java.io.File;
+import java.io.FileWriter;
+
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpSession;
@@ -73,22 +76,28 @@ public class StockController {
 	}
 
 	@PostMapping(AZURE)
-	public ApiResponse receiptStock(HttpSession session, @RequestBody String imgUrl) throws IOException {
+	public ApiResponse receiptStock(HttpSession session, @RequestBody String img_b64_str) throws IOException {
+		// Takes url in body, returns food id's in body as list ex: [21, 38, 2113, 321]
 		Long userId = Utils.getLoggedInUser(session);
-
 		if (userId == null) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
 		}
-		if (imgUrl == null) {
-			imgUrl = "https://raw.githubusercontent.com/Team-W4/eece4792-meal-master/text-recognition/src/text-recognition/receipt-pics/tj1.jpg";
+		if (img_b64_str == null) {
+			throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY);
 		}
-		imgUrl = "https://raw.githubusercontent.com/Team-W4/eece4792-meal-master/text-recognition/src/text-recognition/receipt-pics/tj1.jpg";
+
+		File tempFile = File.createTempFile("imgb64-", ".txt");
+		tempFile.deleteOnExit();
+		FileWriter fileWriter = new FileWriter(tempFile);
+		fileWriter.write(img_b64_str);
+		fileWriter.flush();
+		fileWriter.close();
 
 		String text = new String();
-		if(System.getProperty("os.name").toLowerCase().contains("win")) {
-			text = "eece4792-meal-master/src/text-recognition/dist/parse-receipt/parse-receipt.exe --image_path " + imgUrl;
+		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+			text = "python eece4792-meal-master/src/text-recognition/parse-receipt.py --text_file "+tempFile;
 		} else {
-			text = "parse-receipt_ub/parse-receipt_ub --image_path " + imgUrl;
+			text = "src/text-recognition/dist/parse-receipt_ub/parse-receipt_ub --text_file "+tempFile;
 		}
 
 		Process p = Runtime.getRuntime().exec(text);


### PR DESCRIPTION
changes here are just in stock controller; changed image url requirement for azure to base64 string for images. Using temporary files to pass the strings over to the executable (couldn't pass through execute). temp files are deleted at the end of the request and are guaranteed to be unique 